### PR TITLE
Fix v1.7 TxBuilder empty operations

### DIFF
--- a/src/v1.7/tx/build.ts
+++ b/src/v1.7/tx/build.ts
@@ -32,6 +32,10 @@ export class TxBuilder {
     operations: (MarketOperation | ERC20Operation)[],
     recipient?: Address,
   ): TxArgs[] {
+    if (operations.length === 0) {
+      throw new Error("[@sizecredit/sdk] no operations to execute");
+    }
+
     return operations.map((operation) => {
       if (isMarketOperation(operation)) {
         const { market, functionName, params } = operation;

--- a/test/v1_7.test.ts
+++ b/test/v1_7.test.ts
@@ -251,4 +251,10 @@ describe("@sizecredit/sdk v1.7", () => {
       ),
     );
   });
+
+  test("tx.build should throw on empty operations", () => {
+    expect(() => sdk.tx.build(alice, [])).toThrow(
+      "[@sizecredit/sdk] no operations to execute",
+    );
+  });
 });

--- a/test/v1_8.test.ts
+++ b/test/v1_8.test.ts
@@ -280,4 +280,10 @@ describe("@sizecredit/sdk v1.8", () => {
       sdk.helpers.selector(ISize, "sellCreditMarketOnBehalfOf"),
     );
   });
+
+  test("tx.build should throw on empty operations", () => {
+    expect(() => sdk.tx.build(alice, [])).toThrow(
+      "[@sizecredit/sdk] no operations to execute",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- prevent v1.7 TxBuilder from building empty transaction batches
- add regression tests for both v1.7 and v1.8 builders

## Testing
- `npm ci --ignore-scripts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684037aaa378833289f590bf87265ecb