### PR TITLE
Add operation value tests

### DIFF
--- a/test/v1_7.test.ts
+++ b/test/v1_7.test.ts
@@ -251,4 +251,34 @@ describe("@sizecredit/sdk v1.7", () => {
       ),
     );
   });
+
+  test("deposit with value then borrow", async () => {
+    const value = ethers.utils.parseEther("0.1");
+    const txs = sdk.tx.build(alice, [
+      sdk.market.deposit(
+        market1,
+        {
+          amount: value,
+          to: alice,
+          token: weth,
+        },
+        value,
+      ),
+      sdk.market.sellCreditMarket(market1, {
+        lender: bob,
+        creditPositionId: ethers.constants.MaxUint256,
+        amount: 100n,
+        tenor: 365n * 24n * 60n * 60n,
+        deadline: 1893456000n,
+        maxAPR: ethers.constants.MaxUint256,
+        exactAmountIn: false,
+      }),
+    ]);
+
+    expect(txs.length).toBe(2);
+    expect(txs[0].target).toBe(market1);
+    expect(txs[0].value?.toString()).toBe(value.toString());
+    expect(txs[1].target).toBe(market1);
+    expect(txs[1].value).toBeUndefined();
+  });
 });

--- a/test/v1_8.test.ts
+++ b/test/v1_8.test.ts
@@ -280,4 +280,43 @@ describe("@sizecredit/sdk v1.8", () => {
       sdk.helpers.selector(ISize, "sellCreditMarketOnBehalfOf"),
     );
   });
+
+  test("deposit with value then borrow", async () => {
+    const value = ethers.utils.parseEther("0.1");
+    const txs = sdk.tx.build(alice, [
+      sdk.market.deposit(
+        market1,
+        {
+          amount: value,
+          to: alice,
+          token: weth,
+        },
+        value,
+      ),
+      sdk.market.sellCreditMarket(market1, {
+        lender: bob,
+        creditPositionId: ethers.constants.MaxUint256,
+        amount: 100n,
+        tenor: 365n * 24n * 60n * 60n,
+        deadline: 1893456000n,
+        maxAPR: ethers.constants.MaxUint256,
+        exactAmountIn: false,
+        collectionId: 0,
+        rateProvider: ethers.constants.AddressZero,
+      }),
+    ]);
+
+    expect(txs.length).toBe(1);
+    expect(txs[0].target).toBe(sizeFactory);
+    expect(txs[0].data).toContain(
+      sdk.helpers.selector(ISizeFactory, "callMarket"),
+    );
+    expect(txs[0].data).toContain(
+      sdk.helpers.selector(ISize, "depositOnBehalfOf"),
+    );
+    expect(txs[0].data).toContain(
+      sdk.helpers.selector(ISize, "sellCreditMarketOnBehalfOf"),
+    );
+    expect(txs[0].value).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add v1.7 test for operations array with value
- add v1.8 test for operations array with value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684038504b788332b8cc7dc5d080cec7