### PR TITLE
Restrict coverage to src files

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   collectCoverage: true,
+  collectCoverageFrom: ["src/**/*.{ts,tsx}"],
   coverageDirectory: "coverage",
   coverageReporters: ["text", "lcov"],
   transform: {


### PR DESCRIPTION
## Summary
- only gather coverage from the `src/` directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849716c42448332b24479c80b42e3a9